### PR TITLE
Remove message("Parsing:" slug) from entry.R

### DIFF
--- a/R/entry.R
+++ b/R/entry.R
@@ -226,7 +226,6 @@ Glossary <- R6::R6Class("Glossary",
           }
 
           entries_lang <- e[names(e) %in% iso_langs()]
-          message("parsing: ", slug)
           res <- GlossaryEntry$new(
             slug = slug,
             term = entries_lang[[1]]$term,


### PR DESCRIPTION
This PR is to remove the message("Parsing": slug) from entry.R as it clutters the session when loading each definition in the R console. 